### PR TITLE
Does PHP 7.2 support return typehints? 

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -5,7 +5,7 @@ if (!function_exists('inertia')) {
      * Inertia helper.
      *
      * @param null|string $component
-     * @param array       $props
+     * @param array|\Illuminate\Contracts\Support\Arrayable $props
      *
      * @return \Inertia\ResponseFactory|\Inertia\Response
      */

--- a/helpers.php
+++ b/helpers.php
@@ -4,7 +4,7 @@ if (!function_exists('inertia')) {
     /**
      * Inertia helper.
      *
-     * @param null|string $component
+     * @param null|string                                   $component
      * @param array|\Illuminate\Contracts\Support\Arrayable $props
      *
      * @return \Inertia\ResponseFactory|\Inertia\Response

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static void setRootView($name)
  * @method static void share($key, $value = null)
- * @method static array getShared($key = null)
+ * @method static array getShared($key = null, $default = null)
  * @method static void version($version)
  * @method static int|string getVersion()
  * @method static \Inertia\Response render($component, $props = [])

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -66,7 +66,7 @@ class ResponseFactory
         return new LazyProp($callback);
     }
 
-    public function render($component, $props = [])
+    public function render($component, $props = []): Response
     {
         if ($props instanceof Arrayable) {
             $props = $props->toArray();

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -30,10 +30,10 @@ class ResponseFactory
         }
     }
 
-    public function getShared($key = null)
+    public function getShared($key = null, $default = null)
     {
         if ($key) {
-            return Arr::get($this->sharedProps, $key);
+            return Arr::get($this->sharedProps, $key, $default);
         }
 
         return $this->sharedProps;

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -40,6 +40,11 @@ class ResponseFactory
         return $this->sharedProps;
     }
 
+    public function flushShared()
+    {
+        $this->sharedProps = [];
+    }
+
     public function version($version)
     {
         $this->version = $version;

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -25,6 +25,8 @@ class ResponseFactory
     {
         if (is_array($key)) {
             $this->sharedProps = array_merge($this->sharedProps, $key);
+        } elseif($key instanceof Arrayable) {
+            $this->sharedProps = array_merge($this->sharedProps, $key->toArray());
         } else {
             Arr::set($this->sharedProps, $key, $value);
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -23,6 +23,10 @@ class ServiceProvider extends BaseServiceProvider
             'inertia'
         );
 
+        $this->registerRequestMacro();
+        $this->registerRouterMacro();
+        $this->registerTestingMacros();
+
         $this->app->bind('inertia.testing.view-finder', function ($app) {
             return new FileViewFinder(
                 $app['files'],
@@ -36,9 +40,6 @@ class ServiceProvider extends BaseServiceProvider
     {
         $this->registerBladeDirective();
         $this->registerConsoleCommands();
-        $this->registerRequestMacro();
-        $this->registerRouterMacro();
-        $this->registerTestingMacros();
 
         $this->publishes([
             __DIR__.'/../config/inertia.php' => config_path('inertia.php'),

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -160,7 +160,8 @@ class MiddlewareTest extends TestCase
 
     public function test_middleware_can_change_the_root_view_via_a_property()
     {
-        $this->prepareMockEndpoint(null, [], new class extends Middleware {
+        $this->prepareMockEndpoint(null, [], new class extends Middleware
+        {
             protected $rootView = 'welcome';
         });
 
@@ -171,7 +172,8 @@ class MiddlewareTest extends TestCase
 
     public function test_middleware_can_change_the_root_view_by_overriding_the_rootview_method()
     {
-        $this->prepareMockEndpoint(null, [], new class extends Middleware {
+        $this->prepareMockEndpoint(null, [], new class extends Middleware
+        {
             public function rootView(Request $request)
             {
                 return 'welcome';

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -71,6 +71,14 @@ class ResponseFactoryTest extends TestCase
         ]);
     }
 
+    public function test_can_flush_shared_data()
+    {
+        Inertia::share('foo', 'bar');
+        $this->assertSame(['foo' => 'bar'], Inertia::getShared());
+        Inertia::flushShared();
+        $this->assertSame([], Inertia::getShared());
+    }
+
     public function test_can_create_lazy_prop()
     {
         $factory = new ResponseFactory();

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -71,7 +71,8 @@ class ResponseTest extends TestCase
 
         $user = (object) ['name' => 'Jonathan'];
 
-        $resource = new class($user) extends JsonResource {
+        $resource = new class($user) extends JsonResource
+        {
             public static $wrap = null;
 
             public function toArray($request)
@@ -105,7 +106,8 @@ class ResponseTest extends TestCase
         $callable = function () use ($users) {
             $page = new LengthAwarePaginator($users->take(2), $users->count(), 2);
 
-            return new class($page, JsonResource::class) extends ResourceCollection {
+            return new class($page, JsonResource::class) extends ResourceCollection
+            {
             };
         };
 
@@ -150,7 +152,8 @@ class ResponseTest extends TestCase
 
         $user = (object) ['name' => 'Jonathan'];
 
-        $resource = new class($user) implements Arrayable {
+        $resource = new class($user) implements Arrayable
+        {
             public $user;
 
             public function __construct($user)


### PR DESCRIPTION
`$instance->render($component, $props);` can deal with arrays and arrayable objects, though the docblock on the `inertia` helper function only specifies `array` as a possible type. This causes static analysis tools to complain when you pass in an arrayable.